### PR TITLE
Fix pod-coverage test.

### DIFF
--- a/lib/Method/Signatures/Simple.pm
+++ b/lib/Method/Signatures/Simple.pm
@@ -254,6 +254,14 @@ semantics as 'method' into the current scope:
 
 Overridden.
 
+=item strip_attrs
+
+Overridden.
+
+=item strip_proto
+
+Overridden.
+
 =back
 
 =end pod-coverage


### PR DESCRIPTION
Hi! This is part of the pull-req challenge.
The test is invoked by "dzil test --all". I added the missing symbols to the POD.